### PR TITLE
Cache assets with warnings on failure

### DIFF
--- a/pages/statistiques_detaillees.py
+++ b/pages/statistiques_detaillees.py
@@ -1,6 +1,5 @@
 import streamlit as st, pandas as pd, numpy as np, plotly.express as px
-import json
-from pathlib import Path
+from utils import get_geojson
 
 ENEDIS_COLORS = ["#2C75FF", "#75C700", "#4A9BFF", "#A0D87C", "#0072F0", "#47B361", "#6EABFF", "#9EE08E"]
 
@@ -260,15 +259,12 @@ if "CDT" in flt.columns:
 
 
 
+gj = get_geojson()
 
-geo = Path("arrondissements.geojson")
-
-if "Arr" in flt.columns and geo.exists():
+if "Arr" in flt.columns and gj:
     arr = flt["Arr"].value_counts().rename_axis("Arr").reset_index(name="n")
-    arr["Arr"] = arr["Arr"].astype(int) 
+    arr["Arr"] = arr["Arr"].astype(int)
     arr["pct"] = arr["n"] / arr["n"].sum() * 100
-
-    gj = json.loads(geo.read_text(encoding="utf-8"))
 
     fig = px.choropleth(
         arr,

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+import requests
+import streamlit as st
+
+ROOT = Path(__file__).parent
+LOGO = ROOT / "enedis_logo.png"
+GEO = ROOT / "arrondissements.geojson"
+
+
+def _download(url: str, dest: Path, timeout: int = 15) -> None:
+    """Download a file to dest, show a warning on failure."""
+    try:
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+    except Exception as e:
+        st.warning(f"Impossible de télécharger {url} : {e}")
+        return
+    dest.write_bytes(r.content)
+
+
+@st.cache_resource(show_spinner=False)
+def get_logo_bytes():
+    """Return the logo bytes, downloading it if needed."""
+    if not LOGO.exists():
+        _download(
+            "https://upload.wikimedia.org/wikipedia/fr/7/7d/Enedis_logo.svg",
+            LOGO,
+            timeout=15,
+        )
+    if LOGO.exists():
+        return LOGO.read_bytes()
+    return None
+
+
+@st.cache_resource(show_spinner=False)
+def get_geojson():
+    """Return the GeoJSON data for Paris arrondissements."""
+    if not GEO.exists():
+        _download(
+            "https://opendata.paris.fr/explore/dataset/arrondissements/download/?format=geojson",
+            GEO,
+            timeout=30,
+        )
+    if GEO.exists():
+        try:
+            return json.loads(GEO.read_text(encoding="utf-8"))
+        except Exception as e:
+            st.warning(f"Erreur de lecture {GEO}: {e}")
+    return None


### PR DESCRIPTION
## Summary
- add `utils.py` helper to download/cache resources
- cache static logo and GeoJSON in app
- load cached GeoJSON in detailed stats page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848817b8de0832da5f1a749f47adcd2