### PR TITLE
Remove CDT graph from comparative stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Cette page se concentre sur un technicien sélectionné et reprend la plupart de
 - **Top 10 Libellé BI** et **Top 10 PRM** pour le technicien.
 - **Répartition par Origine** et **volume des programmations par jour**.
 - **Temps théorique vs réalisé par prestation**.
-- **Interventions par agent CDT** : nombre d'apparitions de chaque agent dans la colonne `CDT`.
 - **Interventions par arrondissement** (carte).
 - **Top 10 UO**.
 - Un tableau détaille les lignes correspondant au filtre appliqué.

--- a/pages/statistiques_comparatives.py
+++ b/pages/statistiques_comparatives.py
@@ -167,7 +167,6 @@ bar_cols = [
     ("Libelle du BI", "Top 10 Libellé BI"),
     ("Code et libelle Uo", "Top 10 UO"),
     ("Origine", "Répartition par Origine"),
-    ("CDT", "Interventions par agent CDT"),
 ]
 
 for col, title in bar_cols:


### PR DESCRIPTION
## Summary
- drop CDT chart from comparative statistics page
- update README accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f0798484832da2798ffee764f193